### PR TITLE
Support toplevel divert to set the starting knot

### DIFF
--- a/examples/game.ink
+++ b/examples/game.ink
@@ -1,3 +1,5 @@
+-> back_in_london
+
 === back_in_london ===
 
 We arrived into London at 9.45pm exactly.

--- a/examples/game.lua
+++ b/examples/game.lua
@@ -5,8 +5,6 @@ local pink = require('pink.pink')
 -- 1) Load story
 local story = pink.getStory('examples/game.ink')
 
-story.choosePathString('back_in_london');
-
 while true do
   -- 2) Game content, line by line
   while story.canContinue do

--- a/pink/runtime.lua
+++ b/pink/runtime.lua
@@ -182,5 +182,7 @@ return function (tree)
     -- debug
     s._tree = tree
 
+    update()
+
     return s
 end


### PR DESCRIPTION
A tiny adjustment to the runtime (simply calling `update()` once during initialisation) allows it to run "toplevel" (i.e. outside of any knots) Ink so you can add a divert to the first knot in your Ink directly rather than having to use `choosePathString()` in Lua. Not a huge feature but allows for a bit more idiomatic way of writing Ink :)